### PR TITLE
Add detrending to 2_rotate_data_NE_RT.py

### DIFF
--- a/Processing_Scripts/2_rotate_data_NE_RT.py
+++ b/Processing_Scripts/2_rotate_data_NE_RT.py
@@ -57,7 +57,6 @@ for stadir in stations:
             EVENT= onestation[0].stats['event']
                 
             #detrending
-            onestation.detrend('demean')
             onestation.detrend('linear')
         
             #merge gappy waveforms and overlap


### PR DESCRIPTION
Do we need both 'linear' and 'demean' in the detrending?
Also, my code has an if statement before cutting the components to the same length for seismograms longer than 30 minutes (although these should not be in the dataset)