### PR TITLE
Corrected scripts (#2,#5,#6) to ensure Ptime is calculated w.r.t event time

### DIFF
--- a/Processing_Scripts/2_rotate_data_NE_RT.py
+++ b/Processing_Scripts/2_rotate_data_NE_RT.py
@@ -250,10 +250,9 @@ for stadir in stations:
                 baz_str = '%03d' %(BAZ)
                 dist_str = '%02d' %(DIST)
         
-                ev_str = str(seisZ[0].stats.starttime)
-                filename = stadir + '/' + baz_str + '_' + dist_str + \
-                    '_' + str(seisZ[0].stats.starttime) + '.PICKLE'
-        
+                ev_str = str(seisZ[0].stats.event.origins[0].time)
+                filename = stadir + '/' + baz_str + '_' + dist_str + '_' + ev_str + '.PICKLE'
+                
                 seisnew.write(filename, 'PICKLE')
                 shutil.move(stalist[s], direc)
                 

--- a/Processing_Scripts/5_compute_receiver_functions.py
+++ b/Processing_Scripts/5_compute_receiver_functions.py
@@ -92,7 +92,7 @@ for i in range(len(stalist)):  # range(cat.count()):
         print('done with', stalist[i])
     else:
 
-        Ptime = seis[0].stats['starttime'] + Ptime
+        Ptime = seis[0].stats.event.origins[0].time + Ptime
         vertical = seis.select(channel='*HZ')[0]
         Pref = vertical.slice(Ptime -25.,
             Ptime + 150.)  # Cut out P arrival on vertical

--- a/Processing_Scripts/6_auto_select_receiver_functions.py
+++ b/Processing_Scripts/6_auto_select_receiver_functions.py
@@ -96,7 +96,6 @@ for stadir in stadirs:
                             if np.max(np.abs(RF.data[indm + 40:indm + 1200])) < noiseafter:
                                 if np.max(np.abs(RF.data[indm + 200:-1])) > minamp:
                                     Ptime = seis[0].stats.traveltimes['P']  # set P arrival time
-#                                    Ptime = seis[0].stats['starttime'] + Ptime
                                     Ptime = seis[0].stats.event.origins[0].time + Ptime
                                     
                                     # Sanne SNR measure                                   


### PR DESCRIPTION
Corrected scripts to ensure Ptime is calculated w.r.t seis[0].stats.event.origins[0].time not seis[0].stats['starttime'] which are not always equal for data with gaps/errors etc.

My last commit had this update in turfpy/Processing_Scripts/6_auto_select_receiver_functions.py but not in 2_rotate_data_NE_RT.py or 5_compute_receiver_functions.py	