### PR TITLE
fix minor typos

### DIFF
--- a/Processing_Scripts/6_auto_select_receiver_functions.py
+++ b/Processing_Scripts/6_auto_select_receiver_functions.py
@@ -38,7 +38,7 @@ if len(sys.argv) != 2 or str(sys.argv[1]).lower() == 'help':
     print('                       RF file SNR ratios (V & R components)\n')
     print('Usage:                 >> python3 6_auto_select_receiver_functions.py filterband mindistance maxdistance')
     print('Options [1]:           jgf1, jgf2, jgf3, tff1, tff2, tff3, tff4 or tff5 [str]')
-    print('Options [2,3]:         epicentral distance [int])
+    print('Options [2,3]:         epicentral distance [int]')
     print('Recommended:           python3 6_auto_select_receiver_functions.py jgf1 30 90')
     print('-----------------------------------------------------------------------------------------------------------------------')
     print('\n')

--- a/Processing_Scripts/8_plot_data_perstation.py
+++ b/Processing_Scripts/8_plot_data_perstation.py
@@ -31,7 +31,7 @@ stadirs = glob.glob(direc+'/*')
 
 for stadir in stadirs:
     print(stadir)
-    with open(stadir+'/selected_RFs_jgf1.dat','r') as f:
+    with open(stadir+'/selected_RFs_'+str(filt)+'.dat','r') as f:
         goodrfs= f.read().replace('\n', '')
 
     # loop through events


### PR DESCRIPTION
Minor typo (missing end string literal) that was breaking Processing Script 6 + minor edit to Processing Script 8 that allows it to look for the correct RF file based on filter used.